### PR TITLE
Adds ability to add Nibe Uplink via HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,12 @@
 {
   "name": "Nibe Uplink",
   "content_in_root": true,
-  "iot_class": "Cloud Polling"
+  "iot_class": "Cloud Polling",
+  "domains": [
+    "binary_sensor",
+    "climate",
+    "fan",
+    "sensor",
+    "switch",
+    "water_heater"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -9,4 +9,5 @@
     "sensor",
     "switch",
     "water_heater"
+  ]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Nibe Uplink",
+  "content_in_root": true,
+  "iot_class": "Cloud Polling"
+}


### PR DESCRIPTION
Adding the HACS.json file allows HACS to load and install the component directly, this will simplify the installation for users.

**Note:** Due to https://github.com/custom-components/hacs/issues/577 HACS cannot install the component yet, however the repo can be added.