### PR TITLE
Added check for passive cooling

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -209,6 +209,8 @@ class NibeClimate(NibeEntity, ClimateEntity):
 
     def parse_statuses(self, statuses: Set[str]):
         """Parse status list."""
+        if "Cooling (Passive)" in statuses:
+            self._hvac_action = CURRENT_HVAC_COOL
         if "Heating" in statuses:
             self._hvac_action = CURRENT_HVAC_HEAT
         elif "Cooling" in statuses:

--- a/climate.py
+++ b/climate.py
@@ -211,7 +211,7 @@ class NibeClimate(NibeEntity, ClimateEntity):
         """Parse status list."""
         if "Cooling (Passive)" in statuses:
             self._hvac_action = CURRENT_HVAC_COOL
-        if "Heating" in statuses:
+        elif "Heating" in statuses:
             self._hvac_action = CURRENT_HVAC_HEAT
         elif "Cooling" in statuses:
             self._hvac_action = CURRENT_HVAC_COOL


### PR DESCRIPTION
As listed in https://github.com/elupus/hass_nibe/issues/70, the passive cooling uses the same pump, which is called 'Heating Medium Pump'. This PR adds a first check to see if passive cooling is on to prevent the component from always reporting 'Heating' while in passive cooling mode.

Another options might be to simply change the order of the heating and cooling checks?