### PR TITLE
Control ventilation only with presets

### DIFF
--- a/fan.py
+++ b/fan.py
@@ -16,8 +16,14 @@ from .entity import NibeEntity
 
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
-SPEED_AUTO = "auto"
-SPEED_BOOST = "boost"
+PRESET_VALUES = {
+    "Normal": 0,
+    "Speed 1": 1,
+    "Speed 2": 2,
+    "Speed 3": 3,
+    "Speed 4": 4
+}
+PRESET_NAMES = list(PRESET_VALUES.keys())
 
 
 async def async_setup_entry(
@@ -76,25 +82,14 @@ class NibeFan(NibeEntity, FanEntity):
         return False
 
     @property
-    def percentage(self) -> int | None:
-        """Return the current percentage."""
-        if (value := self.get_value(self._ventilation.fan_speed)) is not None:
-            return int(value)
-        return None
-
-    @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite."""
-        boost = self.get_raw(self._ventilation.ventilation_boost)
-        if boost:
-            return SPEED_BOOST
-        else:
-            return SPEED_AUTO
+        return PRESET_NAMES[self.get_raw(self._ventilation.ventilation_boost)]
 
     @property
     def preset_modes(self):
         """Return a list of available preset modes."""
-        return [SPEED_AUTO, SPEED_BOOST]
+        return PRESET_NAMES
 
     @property
     def extra_state_attributes(self) -> dict[str, str | None]:
@@ -102,6 +97,7 @@ class NibeFan(NibeEntity, FanEntity):
         data = {}
         data["extract_air"] = self.get_value(self._ventilation.extract_air)
         data["exhaust_air"] = self.get_value(self._ventilation.exhaust_air)
+        data["fan_speed"] = self.get_raw(self._ventilation.fan_speed)
         data["ventilation_boost"] = self.get_value(self._ventilation.ventilation_boost)
         data["ventilation_boost_raw"] = self.get_raw(
             self._ventilation.ventilation_boost
@@ -116,20 +112,12 @@ class NibeFan(NibeEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
-        if preset_mode == SPEED_BOOST:
-            value = 1
-        else:
-            value = 0
         assert self._ventilation.ventilation_boost, "Ventilation boost not supported"
         await self._uplink.put_parameter(
             self._system_id,
             self._ventilation.ventilation_boost,
-            value,
+            PRESET_VALUES[preset_mode],
         )
-
-    async def async_set_percentage(self, percentage: int) -> None:
-        """Set an exact percentage."""
-        raise NotImplementedError("Can't set exact speed")
 
     @property
     def unique_id(self) -> str:
@@ -139,4 +127,4 @@ class NibeFan(NibeEntity, FanEntity):
     @property
     def supported_features(self) -> int | None:
         """Return supported features."""
-        return FanEntityFeature.PRESET_MODE | FanEntityFeature.SET_SPEED
+        return FanEntityFeature.PRESET_MODE

--- a/fan.py
+++ b/fan.py
@@ -82,6 +82,13 @@ class NibeFan(NibeEntity, FanEntity):
         return False
 
     @property
+    def percentage(self) -> int | None:
+        """Return the current percentage."""
+        if (value := self.get_value(self._ventilation.fan_speed)) is not None:
+            return int(value)
+        return None
+
+    @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., auto, smart, interval, favorite."""
         return PRESET_NAMES[self.get_raw(self._ventilation.ventilation_boost)]


### PR DESCRIPTION
## Goal
- Use all pre defined ventilation speeds set in the heat pump

## Changes
- Removes "set speed" feature
- Adds 5 speed modes (Normal + 1..4) as presets

## Result
![image](https://user-images.githubusercontent.com/31593025/235319147-7344fdf6-3272-4164-8df4-77654b022a5b.png)

## Extra info
I was having trouble with setting the different ventilation speed modes with this integration for my F470, and came up with this solution.

Reading https://github.com/elupus/hass_nibe/issues/17#issuecomment-515751011 got me thinking it should be possible to set those with the `47260` parameter
It seems that this commit https://github.com/elupus/nibeuplink/commit/1ed805c6d4dd9706452fbae93ce639002d404250 changed the use of `ventilation_boost` to `47260` , which probably "broke" the code for the `fan` entity (`SPEED_BOOST` would now just select speed 1).

The changes in this pull request use the ventilation boost to select all 5 different speed modes, remove all percentage speed references, but adds the current speed percentage as an extra attribute..

--- 

An alternative approach would be to allow both `ventilation_boost` and `47260` params to be set separately in https://github.com/elupus/nibeuplink . Ventilation boost on my F470 sets speed 4 as shown below:
![image](https://user-images.githubusercontent.com/31593025/235319182-4f37ecfb-8693-4bad-b2a6-9bf9919b408e.png)
(don't mind the percentage, in my system this is configured as overpressure so exhaust speed is pretty low 😅 )

One could then configure speed 1, 2 and 3 as low, med, high, and Off would be "Normal". It could look then something more like below (but with a boost mode)
![image](https://user-images.githubusercontent.com/31593025/235319279-f604846a-5da0-4f29-9daf-0168bc84a141.png)

---

### Note
This works on my F470. I have no idea on how universal this is for other Nibe systems