### PR TITLE
Make status titles available as state attribute on NibeSystemSensor

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -379,5 +379,4 @@ class NibeSystemSensor(CoordinatorEntity[NibeSystem], SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, str | None]:
         """Get the attributes (extra state) data from system class."""
-        if hasattr(self.entity_description, "attributes_fn") and callable(getattr(self.entity_description, "attributes_fn")):
-            return self.entity_description.attributes_fn(self._system)
+        return self.entity_description.attributes_fn(self._system)

--- a/sensor.py
+++ b/sensor.py
@@ -343,10 +343,10 @@ SYSTEM_SENSORS: tuple[NibeSystemSensorEntityDescription, ...] = (
         state_fn=lambda x: str(x.software["current"]["name"]) if x.software else None,
     ),
     NibeSystemSensorEntityDescription(
-        key="hasStatus",
-        name="has status",
+        key="statusCount",
+        name="status count",
         entity_category=EntityCategory.DIAGNOSTIC,
-        state_fn=lambda x: len(x.statuses) > 1,
+        state_fn=lambda x: len(x.statuses),
         attributes_fn = lambda x: {"statuses": x.statuses},
     ),
 )

--- a/sensor.py
+++ b/sensor.py
@@ -367,3 +367,10 @@ class NibeSystemSensor(CoordinatorEntity[NibeSystem], SensorEntity):
     def native_value(self) -> StateType:
         """Get the state data from system class."""
         return self.entity_description.state_fn(self._system)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        """Return extra state."""
+        data = {}
+        data["statuses"] = self._system.statuses
+        return data


### PR DESCRIPTION
With this change a user will be able to access a list of heat pump status titles in the `statuses` attribute on the state of all NibeSystemSensor-entities.

For example a template string like this `{{ state_attr('sensor.last_activity', 'statuses') }}` will return the following list:

```json
[
  "Heating Medium Pump",
  "Price Of Electricity",
  "Ventilation",
  "Heating"
]
```

I'm using this to log compressor-status with a template binary_sensor like this:

```yaml
- binary_sensor:
    - name: "Compressor"
      unique_id: "nibe_status_compressor"
      device_class: running
      state: "{{ 'Compressor' in state_attr('sensor.last_activity', 'statuses') }}"
  trigger:
    - platform: event
      event_type: event_template_reloaded
    - platform: state
      entity_id:
        - sensor.last_activity
```

Would also be useful if one wanted to replicate the status icons on their NIBE-system in HomeAssistant, to get a glance at what the unit is doing right now, without having to open the NIBE Uplink app.

As previously stated, I'm currently using this in my current system with great success.